### PR TITLE
fix: Ensure 'saves' directory exists for output files in example scripts

### DIFF
--- a/examples/infer_s2s.py
+++ b/examples/infer_s2s.py
@@ -84,6 +84,7 @@ def infer_example(model_path, audio_path):
     
     # 保存wav文件
     output_uuid = str(uuid.uuid4())
+    os.makedirs('saves', exist_ok=True)
     output_path = f'saves/output_audio_{output_uuid}.wav'
     torchaudio.save(output_path, speech.cpu(), cosyvoice_model.sample_rate)
     print(f"Audio saved to: {output_path}")


### PR DESCRIPTION
Create 'saves' directory if it does not exist before saving audio when running example [infer_s2s.py](https://github.com/FunAudioLLM/Fun-Audio-Chat/blob/main/examples/infer_s2s.py#L87)

Problem: 
Since torchaudio.save() does not automatically create directories, running the example script examples/infer_s2s.py directly will result in an error.
```bash
  File "/root/miniconda3/lib/python3.12/site-packages/soundfile.py", line 343, in write
    with SoundFile(file, 'w', samplerate, channels,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/soundfile.py", line 658, in __init__
    self._file = self._open(file, mode_int, closefd)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/soundfile.py", line 1216, in _open
    raise LibsndfileError(err, prefix="Error opening {0!r}: ".format(self.name))
soundfile.LibsndfileError: Error opening 'saves/output_audio_xxx.wav': System error.
```